### PR TITLE
feat(theme): implement light/dark theme switching functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist
 node_modules
+/CLAUDE.md
+/.idea/

--- a/src/components/common/YamlPreview.tsx
+++ b/src/components/common/YamlPreview.tsx
@@ -1,5 +1,6 @@
 import Editor from '@monaco-editor/react';
 import { Paper, Title, Box } from '@mantine/core';
+import { useThemeStore } from '../../store/useThemeStore';
 
 interface YamlPreviewProps {
   value: string;
@@ -7,6 +8,8 @@ interface YamlPreviewProps {
 }
 
 export default function YamlPreview({ value, title = 'Preview' }: YamlPreviewProps) {
+  const { colorScheme } = useThemeStore();
+
   return (
     <Paper p="0" radius="md" withBorder h="100%" style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       {title && (
@@ -19,7 +22,7 @@ export default function YamlPreview({ value, title = 'Preview' }: YamlPreviewPro
           height="100%"
           defaultLanguage="yaml"
           value={value}
-          theme="vs-dark"
+          theme={colorScheme === 'dark' ? 'vs-dark' : 'light'}
           options={{
             minimap: { enabled: false },
             fontSize: 13,

--- a/src/components/editors/conversation/nodes/AgentNode.tsx
+++ b/src/components/editors/conversation/nodes/AgentNode.tsx
@@ -25,12 +25,13 @@ export default function AgentNode({ data, selected }: NodeProps<AgentNodeData>) 
   const isEntry = !!data.npcId;
 
   return (
-    <Card 
-      shadow="md" 
-      p={0} 
-      radius="md" 
-      withBorder 
-      style={{ 
+    <Card
+      shadow="md"
+      p={0}
+      radius="md"
+      withBorder
+      className="conversation-node-card"
+      style={{
         width: 280,
         borderColor: selected ? 'var(--mantine-color-blue-5)' : (isEntry ? 'var(--mantine-color-orange-6)' : 'var(--mantine-color-dark-4)'),
         borderWidth: 2,
@@ -69,11 +70,12 @@ export default function AgentNode({ data, selected }: NodeProps<AgentNodeData>) 
       </Handle>
 
       {/* Header */}
-      <Box 
+      <Box
         bg={isEntry ? "rgba(253, 126, 20, 0.15)" : "var(--mantine-color-dark-6)"}
-        p="xs" 
+        p="xs"
         h={48}
-        style={{ 
+        className="conversation-node-header"
+        style={{
             borderBottom: '1px solid var(--mantine-color-dark-5)',
             display: 'flex',
             alignItems: 'center',
@@ -85,7 +87,7 @@ export default function AgentNode({ data, selected }: NodeProps<AgentNodeData>) 
                 {isEntry ? <IconMapPin size={14} /> : <IconMessage size={14} />}
             </ThemeIcon>
             <Stack gap={0}>
-                <Text fw={700} size="sm" c="white" lineClamp={1}>{data.label}</Text>
+                <Text fw={700} size="sm" className="conversation-node-title" lineClamp={1}>{data.label}</Text>
                 {isEntry && <Text size="xs" c="orange.3" style={{ lineHeight: 1, fontSize: 10 }}>入口: {data.npcId}</Text>}
             </Stack>
         </Group>
@@ -94,17 +96,18 @@ export default function AgentNode({ data, selected }: NodeProps<AgentNodeData>) 
 
       <Stack gap={0}>
         {/* NPC Section */}
-        <Box p="sm" bg="var(--mantine-color-dark-7)">
+        <Box p="sm" bg="var(--mantine-color-dark-7)" className="conversation-npc-section">
             <Stack gap={6}>
                 {data.npcLines && data.npcLines.length > 0 ? (
                     data.npcLines.map((line, index) => (
-                        <Box 
-                            key={index} 
-                            bg="var(--mantine-color-dark-6)" 
-                            p="xs" 
+                        <Box
+                            key={index}
+                            bg="var(--mantine-color-dark-6)"
+                            p="xs"
+                            className="conversation-npc-bubble"
                             style={{ borderRadius: 6, borderTopLeftRadius: 0 }}
                         >
-                            <Text size="xs" c="gray.3" style={{ whiteSpace: 'pre-wrap', lineHeight: 1.4 }}>
+                            <Text size="xs" style={{ whiteSpace: 'pre-wrap', lineHeight: 1.4 }}>
                                 {line}
                             </Text>
                         </Box>
@@ -116,22 +119,23 @@ export default function AgentNode({ data, selected }: NodeProps<AgentNodeData>) 
         </Box>
 
         {/* Player Section */}
-        <Box bg="var(--mantine-color-dark-8)" style={{ borderTop: '1px solid var(--mantine-color-dark-5)' }}>
+        <Box bg="var(--mantine-color-dark-8)" className="conversation-player-section" style={{ borderTop: '1px solid var(--mantine-color-dark-5)' }}>
             <Stack gap={0}>
                 {data.playerOptions && data.playerOptions.length > 0 ? (
                     data.playerOptions.map((option, index) => (
-                        <Box 
-                            key={option.id} 
+                        <Box
+                            key={option.id}
                             p="xs"
-                            style={{ 
-                                position: 'relative', 
+                            className="conversation-player-option"
+                            style={{
+                                position: 'relative',
                                 borderTop: index > 0 ? '1px solid var(--mantine-color-dark-6)' : 'none',
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'flex-end'
                             }}
                         >
-                            <Text size="xs" c="gray.4" mr={16} ta="right">{option.text || '(Empty)'}</Text>
+                            <Text size="xs" mr={16} ta="right">{option.text || '(Empty)'}</Text>
                             
                             {/* Output Handle */}
                             <Handle 

--- a/src/components/editors/conversation/nodes/SwitchNode.tsx
+++ b/src/components/editors/conversation/nodes/SwitchNode.tsx
@@ -23,12 +23,13 @@ export default function SwitchNode({ id, data, selected }: NodeProps<SwitchNodeD
   }, [data.branches, id, updateNodeInternals]);
 
   return (
-    <Card 
-      shadow="md" 
-      p={0} 
-      radius="md" 
-      withBorder 
-      style={{ 
+    <Card
+      shadow="md"
+      p={0}
+      radius="md"
+      withBorder
+      className="conversation-node-card"
+      style={{
         width: 280,
         borderColor: selected ? 'var(--mantine-color-violet-3)' : 'var(--mantine-color-violet-8)',
         borderWidth: 2,
@@ -58,11 +59,12 @@ export default function SwitchNode({ id, data, selected }: NodeProps<SwitchNodeD
       />
 
       {/* Header */}
-      <Box 
+      <Box
         bg="var(--mantine-color-violet-9)"
-        p="xs" 
+        p="xs"
         h={48}
-        style={{ 
+        className="conversation-node-header"
+        style={{
             borderBottom: '1px solid var(--mantine-color-dark-5)',
             display: 'flex',
             alignItems: 'center',
@@ -75,7 +77,7 @@ export default function SwitchNode({ id, data, selected }: NodeProps<SwitchNodeD
                 <IconGitBranch size={14} />
             </ThemeIcon>
             <Stack gap={0}>
-                <Text fw={700} size="sm" c="white" lineClamp={1}>{data.label}</Text>
+                <Text fw={700} size="sm" className="conversation-node-title" lineClamp={1}>{data.label}</Text>
                 {hasNpcId ? (
                     <Text size="xs" c="violet.3" style={{ lineHeight: 1, fontSize: 10 }}>NPC: {data.npcId}</Text>
                 ) : (
@@ -90,15 +92,16 @@ export default function SwitchNode({ id, data, selected }: NodeProps<SwitchNodeD
       </Box>
 
       {/* Branches Section */}
-      <Box bg="var(--mantine-color-dark-8)">
+      <Box bg="var(--mantine-color-dark-8)" className="conversation-player-section">
         <Stack gap={0}>
             {data.branches && data.branches.length > 0 ? (
                 data.branches.map((branch, index) => (
-                    <Box 
-                        key={branch.id} 
+                    <Box
+                        key={branch.id}
                         p="xs"
-                        style={{ 
-                            position: 'relative', 
+                        className="conversation-player-option"
+                        style={{
+                            position: 'relative',
                             borderTop: index > 0 ? '1px solid var(--mantine-color-dark-6)' : 'none',
                             display: 'flex',
                             flexDirection: 'column',
@@ -108,7 +111,7 @@ export default function SwitchNode({ id, data, selected }: NodeProps<SwitchNodeD
                         <Group justify="space-between" w="100%" mb={4}>
                             <Badge size="xs" variant="outline" color="gray">IF</Badge>
                             <Tooltip label={branch.condition} multiline w={200}>
-                                <Text size="xs" c="gray.3" style={{ fontFamily: 'monospace', cursor: 'help' }} lineClamp={1}>
+                                <Text size="xs" style={{ fontFamily: 'monospace', cursor: 'help' }} lineClamp={1}>
                                     {branch.condition}
                                 </Text>
                             </Tooltip>

--- a/src/components/editors/quest/dynamic/DynamicField.tsx
+++ b/src/components/editors/quest/dynamic/DynamicField.tsx
@@ -71,7 +71,7 @@ export const DynamicField: React.FC<DynamicFieldProps> = ({ field, value, onChan
     return (
         <div className="flex items-stretch border-b border-(--mantine-color-dark-4) last:border-b-0">
             <div className="w-[140px] shrink-0 px-3 py-2 border-r border-(--mantine-color-dark-4) bg-(--mantine-color-dark-8) flex flex-col justify-center">
-                <Text size="sm" fw={500} lh={1.2} c="var(--mantine-color-gray-3)" style={{ wordBreak: 'break-word' }}>{field.name}</Text>
+                <Text size="sm" fw={500} lh={1.2} className="dynamic-field-label" c="var(--mantine-color-gray-3)" style={{ wordBreak: 'break-word' }}>{field.name}</Text>
                 <Text size="xs" c="dimmed" mt={4} style={{ fontSize: 10, fontFamily: 'monospace' }}>{field.pattern}</Text>
             </div>
             <div className="flex-1 flex items-center min-w-0 bg-(--mantine-color-dark-7) hover:bg-(--mantine-color-dark-6) transition-colors">

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,8 +1,9 @@
 import { AppShell, Group, Title, Button, Stack, Text, ScrollArea, ActionIcon, Box, TextInput, Menu, Modal, FileButton, Highlight, SegmentedControl, Badge } from '@mantine/core';
-import { IconPlus, IconTrash, IconFileText, IconSearch, IconEdit, IconDotsVertical, IconDownload, IconUpload, IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand, IconFolderPlus, IconFilePlus, IconSettings } from '@tabler/icons-react';
+import { IconPlus, IconTrash, IconFileText, IconSearch, IconEdit, IconDotsVertical, IconDownload, IconUpload, IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand, IconFolderPlus, IconFilePlus, IconSettings, IconSun, IconMoon } from '@tabler/icons-react';
 import { useState, useEffect, useMemo } from 'react';
 import { useProjectStore, FileType, VirtualFile } from '../../store/useProjectStore';
 import { useApiStore } from '../../store/useApiStore';
+import { useThemeStore } from '../../store/useThemeStore';
 import { parseYaml } from '../../utils/yaml-utils';
 import { FileTree, TreeItem } from '../ui';
 import QuestEditor from '../editors/quest/QuestEditor';
@@ -15,13 +16,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 export default function DashboardLayout() {
   const [activeTab, setActiveTab] = useState<string>('quest');
-  const { 
-    questFiles, questFolders, conversationFiles, conversationFolders, 
-    activeFileId, setActiveFile, 
-    createFile, deleteFile, renameFile, importFiles, moveFile, 
-    createFolder, deleteFolder, renameFolder, moveFolder 
+  const {
+    questFiles, questFolders, conversationFiles, conversationFolders,
+    activeFileId, setActiveFile,
+    createFile, deleteFile, renameFile, importFiles, moveFile,
+    createFolder, deleteFolder, renameFolder, moveFolder
   } = useProjectStore();
   const { setApiData } = useApiStore();
+  const { colorScheme, toggleColorScheme } = useThemeStore();
   
   const files = activeTab === 'quest' ? questFiles : conversationFiles;
   const folders = activeTab === 'quest' ? questFolders : conversationFolders;
@@ -317,8 +319,15 @@ export default function DashboardLayout() {
                 </ActionIcon>
                 <Title order={3} size="h4">Chemdah Lab</Title>
             </Group>
-            
+
             <Group>
+                <ActionIcon
+                    variant="subtle"
+                    onClick={toggleColorScheme}
+                    title={colorScheme === 'dark' ? '切换到亮色模式' : '切换到暗色模式'}
+                >
+                    {colorScheme === 'dark' ? <IconSun size={18} /> : <IconMoon size={18} />}
+                </ActionIcon>
                 <FileButton onChange={handleImportApi} accept=".json">
                     {(props) => <Button {...props} variant="subtle" size="xs" leftSection={<IconSettings size={16} />}>API</Button>}
                 </FileButton>

--- a/src/components/ui/FormScript.tsx
+++ b/src/components/ui/FormScript.tsx
@@ -1,5 +1,6 @@
 import Editor, { EditorProps } from '@monaco-editor/react';
 import { Box, Text, Group, Badge } from '@mantine/core';
+import { useThemeStore } from '../../store/useThemeStore';
 
 interface FormScriptProps extends EditorProps {
     label?: string;
@@ -10,6 +11,8 @@ interface FormScriptProps extends EditorProps {
 }
 
 export function FormScript({ label, description, height = "200px", value, onChange, ...props }: FormScriptProps) {
+    const { colorScheme } = useThemeStore();
+
     const renderLabel = () => {
         if (!label) return null;
         const match = label.match(/^(.*?)\s*\((.*?)\)$/);
@@ -34,7 +37,7 @@ export function FormScript({ label, description, height = "200px", value, onChan
                 <Editor
                     height={height}
                     defaultLanguage="ruby"
-                    theme="vs-dark"
+                    theme={colorScheme === 'dark' ? 'vs-dark' : 'light'}
                     value={value === undefined || value === null ? '' : String(value)}
                     onChange={onChange}
                     options={{

--- a/src/index.css
+++ b/src/index.css
@@ -1,71 +1,272 @@
 @import "tailwindcss";
 
+/* Base Styles */
 html, body, #root {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  background-color: #1a1b1e;
-  color: #c1c2c5;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+/* Dark Mode Styles */
+html[data-mantine-color-scheme="dark"],
+html[data-mantine-color-scheme="dark"] body,
+html[data-mantine-color-scheme="dark"] #root {
+    background-color: #1a1b1e;
+    color: #c1c2c5;
+}
+
+/* Light Mode Styles */
+html[data-mantine-color-scheme="light"],
+html[data-mantine-color-scheme="light"] body,
+html[data-mantine-color-scheme="light"] #root {
+    background-color: #f8f9fa;
+    color: #212529;
+}
+
+/* Override Mantine color variables for light mode */
+html[data-mantine-color-scheme="light"] {
+    /* Map dark colors to light equivalents */
+    --mantine-color-dark-8: #ffffff; /* darkest -> white */
+    --mantine-color-dark-7: #f8f9fa; /* darker -> lightest gray */
+    --mantine-color-dark-6: #e9ecef; /* dark -> light gray */
+    --mantine-color-dark-5: #dee2e6; /* medium -> medium gray */
+    --mantine-color-dark-4: #ced4da; /* light -> darker gray (borders) */
+    --mantine-color-dark-3: #adb5bd;
+    --mantine-color-dark-2: #868e96;
+    --mantine-color-dark-1: #495057;
+    --mantine-color-dark-0: #343a40;
+
+    /* Gray colors for borders in light mode */
+    --mantine-color-gray-0: #f8f9fa;
+    --mantine-color-gray-1: #f1f3f5;
+    --mantine-color-gray-2: #e9ecef;
+    --mantine-color-gray-3: #bfbfbf;
+
 }
 
 .file-tree-item {
-  transition: background-color 0.2s ease;
-  border-radius: 0.2rem;
+    transition: all 0.2s ease;
+    border-radius: 0.2rem;
 }
 
-.file-tree-item:hover {
-  background-color: var(--mantine-color-dark-6);
+/* Dark Mode */
+html[data-mantine-color-scheme="dark"] .file-tree-item:hover {
+    background-color: var(--mantine-color-dark-6);
 }
 
-.file-tree-item.selected {
-  background-color: rgba(34, 139, 230, 0.15);
+html[data-mantine-color-scheme="dark"] .file-tree-item.selected {
+    background-color: rgba(34, 139, 230, 0.15);
 }
 
-.file-tree-item.selected:hover {
-  background-color: rgba(34, 139, 230, 0.25);
+html[data-mantine-color-scheme="dark"] .file-tree-item.selected:hover {
+    background-color: rgba(34, 139, 230, 0.25);
 }
 
-.file-tree-item.drop-target {
-  background-color: rgba(34, 139, 230, 0.15);
-  box-shadow: inset 0 0 0 1px #228be6;
+html[data-mantine-color-scheme="dark"] .file-tree-item.drop-target {
+    background-color: rgba(34, 139, 230, 0.15);
+    box-shadow: inset 0 0 0 1px #228be6;
+}
+
+html[data-mantine-color-scheme="dark"] .file-tree-actions {
+    background-color: var(--mantine-color-dark-6);
+}
+
+/* Light Mode */
+html[data-mantine-color-scheme="light"] .file-tree-item:hover {
+    background-color: rgba(34, 139, 230, 0.08);
+    border-left: 3px solid var(--mantine-color-blue-5);
+    padding-left: calc(0.5rem - 3px);
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-item:hover * {
+    color: #1971c2 !important; /* 强制使用主题色文字 */
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-item.selected {
+    background-color: rgba(34, 139, 230, 0.12);
+    border-left: 3px solid var(--mantine-color-blue-6);
+    padding-left: calc(0.5rem - 3px);
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-item.selected * {
+    color: #1864ab !important; /* 更深的蓝色 */
+    font-weight: 500;
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-item.selected:hover {
+    background-color: rgba(34, 139, 230, 0.18);
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-item.drop-target {
+    background-color: rgba(34, 139, 230, 0.12);
+    box-shadow: inset 0 0 0 2px #228be6;
+}
+
+html[data-mantine-color-scheme="light"] .file-tree-actions {
+    background-color: var(--mantine-color-gray-1);
 }
 
 .file-tree-actions {
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  background-color: var(--mantine-color-dark-6);
+    opacity: 0;
+    transition: opacity 0.2s ease;
 }
 
 .file-tree-item:hover .file-tree-actions,
 .file-tree-actions:focus-within {
-  opacity: 1;
+    opacity: 1;
 }
 
 .task-list-item {
-  transition: background-color 0.2s ease;
-  margin: 2px 0;
+    transition: all 0.2s ease;
+    margin: 2px 0;
 }
 
-.task-list-item:hover {
-  background-color: var(--mantine-color-dark-6) !important;
+/* Dark Mode */
+html[data-mantine-color-scheme="dark"] .task-list-item:hover {
+    background-color: var(--mantine-color-dark-6) !important;
 }
 
-.task-list-item[data-active="true"] {
-  background-color: rgba(34, 139, 230, 0.15) !important;
-  color: #74c0fc !important;
+html[data-mantine-color-scheme="dark"] .task-list-item[data-active="true"] {
+    background-color: rgba(34, 139, 230, 0.15) !important;
+    color: #74c0fc !important;
 }
 
-.task-list-item[data-active="true"]:hover {
-  background-color: rgba(34, 139, 230, 0.25) !important;
+html[data-mantine-color-scheme="dark"] .task-list-item[data-active="true"]:hover {
+    background-color: rgba(34, 139, 230, 0.25) !important;
+}
+
+/* Light Mode */
+html[data-mantine-color-scheme="light"] .task-list-item:hover {
+    background-color: rgba(34, 139, 230, 0.08) !important;
+    border-left: 3px solid var(--mantine-color-blue-5) !important;
+    padding-left: calc(0.75rem - 3px) !important;
+}
+
+html[data-mantine-color-scheme="light"] .task-list-item:hover * {
+    color: #1971c2 !important; /* 主题色文字 */
+}
+
+html[data-mantine-color-scheme="light"] .task-list-item[data-active="true"] {
+    background-color: rgba(34, 139, 230, 0.15) !important;
+    color: #1971c2 !important;
+    border-left: 3px solid var(--mantine-color-blue-6) !important;
+    padding-left: calc(0.75rem - 3px) !important;
+    font-weight: 600 !important;
+}
+
+html[data-mantine-color-scheme="light"] .task-list-item[data-active="true"] * {
+    color: #1864ab !important; /* 更深的蓝色 */
+}
+
+html[data-mantine-color-scheme="light"] .task-list-item[data-active="true"]:hover {
+    background-color: rgba(34, 139, 230, 0.22) !important;
 }
 
 .task-list-actions {
-  opacity: 0;
-  transition: opacity 0.2s ease;
+    opacity: 0;
+    transition: opacity 0.2s ease;
 }
 
 .task-list-item:hover .task-list-actions,
 .task-list-actions[aria-expanded="true"] {
-  opacity: 1;
+    opacity: 1;
+}
+
+/* Conversation Node Styles */
+.conversation-npc-bubble {
+    transition: all 0.2s ease;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-npc-bubble {
+    background-color: #e3f2fd !important; /* 浅蓝色，类似聊天气泡 */
+    border: 1px solid #90caf9 !important;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-npc-bubble * {
+    color: #1565c0 !important; /* 深蓝色文字，确保可读性 */
+}
+
+html[data-mantine-color-scheme="light"] .conversation-npc-bubble:hover {
+    background-color: #bbdefb !important;
+    border-color: #64b5f6 !important;
+    box-shadow: 0 2px 4px rgba(33, 150, 243, 0.15) !important;
+}
+
+.conversation-player-option {
+    transition: all 0.2s ease;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-player-option {
+    background-color: #f1f8e9 !important; /* 浅绿色，区分玩家选项 */
+    border-left: 3px solid transparent !important;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-player-option * {
+    color: #2e7d32 !important; /* 深绿色文字 */
+}
+
+html[data-mantine-color-scheme="light"] .conversation-player-option:hover {
+    background-color: #dcedc8 !important;
+    border-left: 3px solid #66bb6a !important;
+    box-shadow: 0 2px 4px rgba(76, 175, 80, 0.15) !important;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-player-option:hover * {
+    color: #1b5e20 !important; /* hover 时更深的绿色 */
+}
+
+html[data-mantine-color-scheme="light"] .conversation-player-section {
+    background-color: #fafafa !important;
+}
+
+/* Conversation node card and header text colors in light mode */
+html[data-mantine-color-scheme="light"] .conversation-node-card {
+    background-color: #ffffff !important;
+    border-color: #dee2e6 !important;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-node-header {
+    background-color: #f8f9fa !important;
+}
+
+html[data-mantine-color-scheme="light"] .conversation-node-header * {
+    color: #212529 !important; /* 深色文字 */
+}
+
+html[data-mantine-color-scheme="light"] .conversation-node-title {
+    color: #1864ab !important; /* 标题使用主题色 */
+}
+
+html[data-mantine-color-scheme="light"] .conversation-npc-section {
+    background-color: #f8f9fa !important;
+}
+
+/* Dynamic Field Labels in light mode */
+html[data-mantine-color-scheme="light"] .dynamic-field-label {
+    color: #495057 !important; /* 深灰色，确保在浅色背景上可读 */
+}
+
+/* Mantine Select Group Labels in light mode */
+html[data-mantine-color-scheme="light"] .mantine-Select-group {
+    background-color: #f8f9fa !important;
+    color: #495057 !important;
+}
+
+html[data-mantine-color-scheme="light"] .mantine-Select-groupLabel {
+    color: #495057 !important;
+}
+
+/* Mantine Select Dropdown in light mode */
+html[data-mantine-color-scheme="light"] .mantine-Select-dropdown {
+    background-color: #ffffff !important;
+    border-color: #dee2e6 !important;
+}
+
+html[data-mantine-color-scheme="light"] .mantine-Select-option {
+    color: #212529 !important;
+}
+
+html[data-mantine-color-scheme="light"] .mantine-Select-option:hover {
+    background-color: rgba(34, 139, 230, 0.08) !important;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { MantineProvider, createTheme } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import { useThemeStore } from './store/useThemeStore';
 
 import App from './App'
 import '@mantine/core/styles.css';
@@ -14,6 +15,17 @@ const theme = createTheme({
   defaultRadius: 'md',
   fontFamily: 'Inter, sans-serif',
 });
+
+function ThemedApp() {
+  const { colorScheme } = useThemeStore();
+
+  return (
+    <MantineProvider theme={theme} defaultColorScheme={colorScheme} forceColorScheme={colorScheme}>
+      <Notifications />
+      <App />
+    </MantineProvider>
+  );
+}
 
 class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean, error: any }> {
   constructor(props: any) {
@@ -43,10 +55,7 @@ class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { has
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <MantineProvider theme={theme} defaultColorScheme="dark" forceColorScheme="dark">
-        <Notifications />
-        <App />
-      </MantineProvider>
+      <ThemedApp />
     </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type ColorScheme = 'light' | 'dark';
+
+interface ThemeState {
+  colorScheme: ColorScheme;
+  toggleColorScheme: () => void;
+  setColorScheme: (scheme: ColorScheme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      colorScheme: 'dark',
+      toggleColorScheme: () =>
+        set((state) => ({
+          colorScheme: state.colorScheme === 'dark' ? 'light' : 'dark',
+        })),
+      setColorScheme: (scheme) => set({ colorScheme: scheme }),
+    }),
+    {
+      name: 'chemdah-theme-storage',
+    }
+  )
+);


### PR DESCRIPTION
- Added theme store with zustand for managing color scheme state
- Implemented theme toggle button in dashboard layout header
- Updated Monaco editor themes to switch between vs-dark and light
- Added comprehensive CSS styles for both light and dark modes
- Enhanced conversation node components with theme-aware styling
- Updated file tree and task list items with light mode hover states
- Added persistence for theme preference in local storage
- Modified MantineProvider to use dynamic color scheme
- Updated component class names for better theme targeting
- Added theme-aware background colors and text styles throughout UI