### PR TITLE
feat: 文件导入与 API 文件导入支持批量多选

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /.idea/
 /ex-api.json
 /.claude/
+.ace-tool/

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -233,69 +233,90 @@ export default function DashboardLayout() {
     }
   };
 
-  const handleImport = async (file: File | null) => {
-    if (!file) return;
-    
-    try {
+  const handleImport = async (files: File[] | null) => {
+    if (!files || files.length === 0) return;
+
+    const allNewFiles: VirtualFile[] = [];
+    let successCount = 0;
+    let failCount = 0;
+    const errors: string[] = [];
+
+    for (const file of files) {
+      try {
         if (file.name.endsWith('.zip')) {
-            const zip = await JSZip.loadAsync(file);
-            const newFiles: VirtualFile[] = [];
-            
-            for (const [relativePath, zipEntry] of Object.entries(zip.files)) {
-                if (!zipEntry.dir) {
-                    const content = await zipEntry.async('string');
-                    const name = relativePath.split('/').pop() || 'unknown';
-                    const type = relativePath.includes('quest') ? 'quest' : 'conversation'; // Simple heuristic
-                    const path = relativePath.substring(0, relativePath.lastIndexOf('/')) || '';
-                    
-                    newFiles.push({
-                        id: uuidv4(),
-                        name,
-                        type: type as FileType,
-                        content,
-                        path
-                    });
-                }
-            }
-            importFiles(newFiles);
-            notifications.show({
-                title: '导入成功',
-                message: `成功导入 ${newFiles.length} 个文件`,
-                color: 'green'
-            });
-        } else if (file.name.endsWith('.yml') || file.name.endsWith('.yaml')) {
-            const content = await file.text();
-            const data = parseYaml(content);
-            let type: FileType = activeTab as FileType;
+          const zip = await JSZip.loadAsync(file);
+          for (const [relativePath, zipEntry] of Object.entries(zip.files)) {
+            if (!zipEntry.dir) {
+              const content = await zipEntry.async('string');
+              const name = relativePath.split('/').pop() || 'unknown';
+              const type = relativePath.includes('quest') ? 'quest' : 'conversation';
+              const path = relativePath.substring(0, relativePath.lastIndexOf('/')) || '';
 
-            if (data && typeof data === 'object') {
-                const hasConversationFeatures = Object.values(data).some((node: any) => node && (node.npc || node.player));
-                const hasQuestFeatures = Object.values(data).some((node: any) => node && (node.meta || node.task));
-
-                if (hasConversationFeatures) type = 'conversation';
-                else if (hasQuestFeatures) type = 'quest';
-            }
-
-            importFiles([{
+              allNewFiles.push({
                 id: uuidv4(),
-                name: file.name,
-                type,
+                name,
+                type: type as FileType,
                 content,
-                path: ''
-            }]);
+                path
+              });
+              successCount++;
+            }
+          }
+        } else if (file.name.endsWith('.yml') || file.name.endsWith('.yaml')) {
+          const content = await file.text();
+          const data = parseYaml(content);
+          let type: FileType = activeTab as FileType;
 
-            notifications.show({
-                title: '导入成功',
-                message: `成功导入文件 ${file.name} (${type === 'quest' ? '任务' : '对话'})`,
-                color: 'green'
-            });
+          if (data && typeof data === 'object') {
+            const hasConversationFeatures = Object.values(data).some((node: any) => node && (node.npc || node.player));
+            const hasQuestFeatures = Object.values(data).some((node: any) => node && (node.meta || node.task));
+
+            if (hasConversationFeatures) type = 'conversation';
+            else if (hasQuestFeatures) type = 'quest';
+          }
+
+          allNewFiles.push({
+            id: uuidv4(),
+            name: file.name,
+            type,
+            content,
+            path: ''
+          });
+          successCount++;
+        } else {
+          failCount++;
+          errors.push(`${file.name} (不支持的格式)`);
         }
-    } catch (error) {
-        notifications.show({
-            title: '导入失败',
-            message: '无法导入项目文件',
-            color: 'red'
-        });
+      } catch (error: any) {
+        failCount++;
+        errors.push(`${file.name} (${error?.message || '解析失败'})`);
+      }
+    }
+
+    if (allNewFiles.length > 0) {
+      importFiles(allNewFiles);
+    }
+
+    if (failCount === 0) {
+      notifications.show({
+        title: '导入成功',
+        message: `成功导入 ${successCount} 个文件`,
+        color: 'green'
+      });
+    } else if (successCount > 0) {
+      notifications.show({
+        title: '部分导入成功',
+        message: `成功 ${successCount} 个，失败 ${failCount} 个: ${errors.join(', ')}`,
+        color: 'yellow',
+        autoClose: 8000
+      });
+    } else {
+      notifications.show({
+        title: '导入失败',
+        message: `全部 ${failCount} 个文件导入失败: ${errors.join(', ')}`,
+        color: 'red',
+        autoClose: 8000
+      });
     }
   };
 
@@ -341,7 +362,7 @@ export default function DashboardLayout() {
                 >
                     API 中心
                 </Button>
-                <FileButton onChange={handleImport} accept=".zip,.yml,.yaml">
+                <FileButton onChange={handleImport} accept=".zip,.yml,.yaml" multiple>
                     {(props) => <Button {...props} variant="subtle" size="xs" leftSection={<IconUpload size={16} />}>导入</Button>}
                 </FileButton>
                 <Menu shadow="md" width={200}>

--- a/src/components/pages/ApiCenterPage.tsx
+++ b/src/components/pages/ApiCenterPage.tsx
@@ -70,30 +70,50 @@ export function ApiCenterPage() {
     setNewUrl('');
   };
 
-  const handleFileUpload = async (file: File | null) => {
-    if (!file) return;
+  const handleFileUpload = async (files: File[] | null) => {
+    if (!files || files.length === 0) return;
 
-    try {
-      const text = await file.text();
-      const data = JSON.parse(text);
+    let successCount = 0;
+    let failCount = 0;
+    const errors: string[] = [];
 
-      // Use filename without extension as name
-      const name = file.name.replace(/\.[^/.]+$/, '');
-      addLocalSource(name, data);
+    for (const file of files) {
+      try {
+        const text = await file.text();
+        const data = JSON.parse(text);
 
-      // Sync to API Store
+        const name = file.name.replace(/\.[^/.]+$/, '');
+        addLocalSource(name, data);
+        successCount++;
+      } catch (error: any) {
+        failCount++;
+        errors.push(`${file.name} (${error?.message || '解析失败'})`);
+      }
+    }
+
+    if (successCount > 0) {
       syncFromApiCenter();
+    }
 
+    if (failCount === 0) {
       notifications.show({
         title: '上传成功',
-        message: `API 文件 "${name}" 已添加`,
+        message: `成功上传 ${successCount} 个 API 文件`,
         color: 'green'
       });
-    } catch (error: any) {
+    } else if (successCount > 0) {
+      notifications.show({
+        title: '部分上传成功',
+        message: `成功 ${successCount} 个，失败 ${failCount} 个: ${errors.join(', ')}`,
+        color: 'yellow',
+        autoClose: 8000
+      });
+    } else {
       notifications.show({
         title: '上传失败',
-        message: error.message || '无法解析 JSON 文件',
-        color: 'red'
+        message: `全部 ${failCount} 个文件上传失败: ${errors.join(', ')}`,
+        color: 'red',
+        autoClose: 8000
       });
     }
   };
@@ -331,10 +351,10 @@ export function ApiCenterPage() {
                   <Text size="sm" c="dimmed">
                     上传本地 JSON 格式的 API 定义文件。文件名将作为源名称。上传后的数据会持久化保存在本地浏览器中。
                   </Text>
-                  <FileButton onChange={handleFileUpload} accept=".json">
+                  <FileButton onChange={handleFileUpload} accept=".json" multiple>
                     {(props) => (
                       <Button {...props} leftSection={<IconUpload size={16} />} size="lg">
-                        选择文件上传
+                        选择文件上传（支持多选）
                       </Button>
                     )}
                   </FileButton>


### PR DESCRIPTION
## 改动内容

让「文件导入」和「API 中心本地文件导入」都支持批量多选。

### DashboardLayout 文件导入
- \FileButton\ 增加 \multiple\，支持多选 \.zip\ / \.yml\ / \.yaml\
- \handleImport\ 改为接收 \File[]\，逐个解析后统一 \importFiles\，支持 zip + yml 混合多选
- 通知区分「全部成功 / 部分成功 / 全部失败」三种情况，失败时列出具体文件名与原因

### ApiCenterPage API 文件上传
- \FileButton\ 增加 \multiple\，支持多选 \.json\
- \handleFileUpload\ 改为接收 \File[]\，逐个 JSON 解析 \ddLocalSource\，全部完成后再 \syncFromApiCenter\
- 同样区分三种通知状态，失败时列出具体文件名和错误

### 其他
- \.gitignore\ 忽略 \.ace-tool/\

## 验证
- \	sc --noEmit\ 通过
- \ite build\ 通过